### PR TITLE
Make default api_url language specific

### DIFF
--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -35,13 +35,13 @@ class MediaWiki(object):
     :type rate_limit_wait: timedelta
     '''
 
-    def __init__(self, url='http://en.wikipedia.org/w/api.php', lang='en',
+    def __init__(self, url='http://{lang}.wikipedia.org/w/api.php', lang='en',
                  timeout=None, rate_limit=False,
                  rate_limit_wait=timedelta(milliseconds=50)):
         ''' Init Function '''
         self._version = VERSION
-        self._api_url = url
-        self.language = lang  # Make sure URL is updated for language
+        self._api_url = url.format(lang=lang)
+        self._lang = lang
         self._timeout = timeout
         self._user_agent = ('python-mediawiki/VERSION-{0}'
                             '/({1})/BOT').format(VERSION, URL)
@@ -217,7 +217,7 @@ class MediaWiki(object):
         return self._cache
 
     # non-properties
-    def set_api_url(self, api_url='http://en.wikipedia.org/w/api.php',
+    def set_api_url(self, api_url='http://{lang}.wikipedia.org/w/api.php',
                     lang='en'):
         ''' Set the API URL and language
 
@@ -231,7 +231,7 @@ class MediaWiki(object):
         '''
         old_api_url = self._api_url
         old_lang = self._lang
-        self._api_url = api_url
+        self._api_url = api_url.format(lang=lang)
         self._lang = lang
         try:
             self._get_site_info()

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -41,7 +41,7 @@ class MediaWiki(object):
         ''' Init Function '''
         self._version = VERSION
         self._api_url = url
-        self._lang = lang  # should this call self.language = lang?
+        self.language = lang  # Make sure URL is updated for language
         self._timeout = timeout
         self._user_agent = ('python-mediawiki/VERSION-{0}'
                             '/({1})/BOT').format(VERSION, URL)


### PR DESCRIPTION
Without this you have to pass both `url` and `lang` to get a non-English Wikipedia to work.