### PR TITLE
Table of contents

### DIFF
--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -468,7 +468,6 @@ class MediaWikiPage(object):
         self._table_of_contents = res
         return self._table_of_contents
 
-
     def section(self, section_title):
         ''' Plain text section content
 

--- a/tests/mediawiki_test.py
+++ b/tests/mediawiki_test.py
@@ -1098,6 +1098,21 @@ class TestMediaWikiPage(unittest.TestCase):
         self.assertEqual(self.pag.sections,
                          self.response['arya']['sections'])
 
+    def test_table_of_contents(self):
+        ''' test a page table of contents '''
+
+        def _flatten_toc(_dict, res):
+            ''' flatten the table of contents into a list '''
+            for key, val in _dict.items():
+                res.append(key)
+                if val.keys():
+                    _flatten_toc(val, res)
+
+        toc = self.pag.table_of_contents
+        toc_ord = list()
+        _flatten_toc(toc, toc_ord)
+        self.assertEqual(toc_ord, self.response['arya']['sections'])
+
     def test_page_section(self):
         ''' test a page returning a section '''
         self.assertEqual(self.pag.section('A Game of Thrones'),

--- a/tests/mediawiki_test.py
+++ b/tests/mediawiki_test.py
@@ -306,6 +306,17 @@ class TestMediaWiki(unittest.TestCase):
         self.assertNotEqual(time1, time2)
         self.assertGreater(time2, time1)
 
+    def test_cat_prefix(self):
+        ''' test the default category prefix'''
+        site = MediaWikiOverloaded()
+        self.assertEqual(site.category_prefix, 'Category')
+
+    def test_cat_prefix_change(self):
+        ''' test changing the category prefix '''
+        site = MediaWikiOverloaded()
+        self.assertEqual(site.category_prefix, 'Category')
+        site.category_prefix = 'Something:'
+        self.assertEqual(site.category_prefix, 'Something')
 
 class TestMediaWikiLogin(unittest.TestCase):
     ''' Test login functionality '''


### PR DESCRIPTION
Resolves #62 

OrderedDict version of the table of contents. Allows for sub-categories to be correctly placed, in order that they appear on the page.