### PR TITLE
#65 Implementation of API:Langlinks property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # PyPi
 .pypirc
+
+# PyCharm files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MediaWiki Changelog
 
+## Version 0.5.1
+
+* Added Table of Contents parsing based on sections: result is an OrderedDict
+* Fix issue where some sections are not pulled correctly
+
 ## Version 0.5.0
 
 * Add support for logging into the MediaWiki site [issue #59](https://github.com/barrust/mediawiki/issues/48)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # MediaWiki Changelog
 
+## Version 0.5.2
+
+* Add `langlinks` property to `MediaWikiPage` [issue #65](https://github.com/barrust/mediawiki/issues/65)
+
 ## Version 0.5.1
 
 * Added Table of Contents parsing based on sections: result is an OrderedDict
-* Fix issue where some sections are not pulled correctly
+* Fix issue where some sections are not pulled correctly [issue #64](https://github.com/barrust/mediawiki/issues/64)
 
 ## Version 0.5.0
 

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ Pull a MediaWiki page and some of the page properties:
     >>> p.title
     >>> p.summary
     >>> p.categories
+    >>> p.langlinks
     >>> p.images
     >>> p.links
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -214,8 +214,8 @@ Other Properties
 """"""""""""""""
 
 Other properties for a page include: `content`, `html`, `images`, `references`,
-`categories`, `coordinates`, `redirects`, `backlinks`, `summary`, `sections`,
-`logos`, and `hatnotes`
+`categories`, `langlinks`, `coordinates`, `redirects`, `backlinks`, `summary`,
+`sections`, `logos`, and `hatnotes`
 
 Summarize
 """"""""""""""""

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -16,7 +16,7 @@ from .mediawikipage import (MediaWikiPage)
 from .utilities import (memoize)
 
 URL = 'https://github.com/barrust/mediawiki'
-VERSION = '0.5.0'
+VERSION = '0.5.1'
 
 
 class MediaWiki(object):

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -16,7 +16,7 @@ from .mediawikipage import (MediaWikiPage)
 from .utilities import (memoize)
 
 URL = 'https://github.com/barrust/mediawiki'
-VERSION = '0.5.1'
+VERSION = '0.5.2'
 
 
 class MediaWiki(object):

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -446,8 +446,17 @@ class MediaWikiPage(object):
         try:
             content = self.content
             index = content.index(section) + len(section)
+
+            # ensure we have the full section header...
+            while True:
+                if content[index + 1] == '=':
+                    index += 1
+                else:
+                    break
         except ValueError:
             return None
+        except IndexError:
+            pass
 
         try:
             next_index = self.content.index('==', index)

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -74,7 +74,7 @@ class MediaWikiPage(object):
 
         preload_props = ['content', 'summary', 'images', 'references', 'links',
                          'sections', 'redirects', 'coordinates', 'backlinks',
-                         'categories', 'langlinks']
+                         'categories']
         if preload:
             for prop in preload_props:
                 getattr(self, prop)
@@ -286,25 +286,26 @@ class MediaWikiPage(object):
 
     @property
     def langlinks(self):
-        """
+        """List of other languages in which page is available.
+
         Gets a list of all language links from the provided pages to other
         languages according to: https://www.mediawiki.org/wiki/API:Langlinks
-        Note: Not settable.
-        :return: {<lang_code>: <native page title>}
+        Note:
+            Not settable.
+        Returns:
+            {<lang_code>: <native page title>}
         """
         if self._langlinks is False:
-
-            def _get_lang(val):
-                """ parse the lang correctly """
-                lang = val['lang']
-                title = val['*']
-                return lang, title
-
             params = {
                 'prop': 'langlinks',
                 'cllimit': 'max',
             }
-            self._langlinks = dict(_get_lang(lang_link) for lang_link in self._continued_query(params))
+            query_result = self._continued_query(params)
+
+            langlinks = dict()
+            for lang_info in query_result:
+                langlinks[lang_info['lang']] = lang_info['*']
+            self._langlinks = langlinks
         return self._langlinks
 
     @property

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -59,6 +59,7 @@ class MediaWikiPage(object):
         self._images = False
         self._references = False
         self._categories = False
+        self._langlinks = False
         self._coordinates = False
         self._links = False
         self._redirects = False
@@ -73,7 +74,7 @@ class MediaWikiPage(object):
 
         preload_props = ['content', 'summary', 'images', 'references', 'links',
                          'sections', 'redirects', 'coordinates', 'backlinks',
-                         'categories']
+                         'categories', 'langlinks']
         if preload:
             for prop in preload_props:
                 getattr(self, prop)
@@ -282,6 +283,29 @@ class MediaWikiPage(object):
             tmp = [_get_cat(link) for link in self._continued_query(params)]
             self._categories = sorted(tmp)
         return self._categories
+
+    @property
+    def langlinks(self):
+        """
+        Gets a list of all language links from the provided pages to other
+        languages according to: https://www.mediawiki.org/wiki/API:Langlinks
+        Note: Not settable.
+        :return: {<lang_code>: <native page title>}
+        """
+        if self._langlinks is False:
+
+            def _get_lang(val):
+                """ parse the lang correctly """
+                lang = val['lang']
+                title = val['*']
+                return lang, title
+
+            params = {
+                'prop': 'langlinks',
+                'cllimit': 'max',
+            }
+            self._langlinks = dict(_get_lang(lang_link) for lang_link in self._continued_query(params))
+        return self._langlinks
 
     @property
     def coordinates(self):

--- a/tests/mediawiki_test.py
+++ b/tests/mediawiki_test.py
@@ -51,6 +51,7 @@ class MediaWikiOverloaded(MediaWiki):
 
 class TestMediaWiki(unittest.TestCase):
     ''' test the MediaWiki Class Basic functionality '''
+
     def test_version(self):
         ''' test version information '''
         site = MediaWikiOverloaded()
@@ -1063,6 +1064,10 @@ class TestMediaWikiPage(unittest.TestCase):
         self.assertEqual(self.pag.categories,
                          self.response['arya']['categories'])
 
+    def test_page_langlinks(self):
+        ''' test pulling wikimedia supported langlinks '''
+        raise NotImplementedError()  # TODO
+
     def test_page_references(self):
         ''' test a page references '''
         self.assertEqual(self.pag.references,
@@ -1389,6 +1394,7 @@ class TestMediaWikiCategoryTree(unittest.TestCase):
 
     def test_unretrievable_cat(self):
         ''' test throwing the exception when cannot retrieve category tree '''
+
         def new_cattreemem():
             ''' force exception to be thrown '''
             raise Exception


### PR DESCRIPTION
I need your accept to decide if proposed format of values returned by `langlinks` property may be: `{<lang_code>: <native page title>}`.
Consider that in future you might want to add option to configure additional request fields, but then some function will be used, not property.

If you agree, I will have to edit json mockups and write tests.