### PR TITLE
Slots usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Pipfile*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pylintrc
+++ b/.pylintrc
@@ -115,7 +115,7 @@ single-line-if-stmt=no
 no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=1250
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
 # tab).
@@ -321,7 +321,7 @@ int-import-graph=
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=8
+max-args=12
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
 language: python
-matrix:
+jobs:
     include:
-        - python: 2.7
-        - python: 3.4
-        - python: 3.5
-        - python: 3.6
-        - python: 3.7
+        - os: linux
+          dist: bionic
+          python: 2.7
+        - os: linux
           dist: xenial
-          sudo: true
+          python: 3.4
+        - os: linux
+          dist: xenial
+          python: 3.5
+        - os: linux
+          dist: bionic
+          python: 3.6
+        - os: linux
+          dist: bionic
+          python: 3.7
+        - os: linux
+          dist: bionic
+          python: 3.8
 
 # install python dependencies including this package in the travis
 # virtualenv

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -852,13 +852,12 @@ class MediaWiki(object):
                 Title takes precedence over pageid if both are provided """
         if (title is None or title.strip() == "") and pageid is None:
             raise ValueError("Either a title or a pageid must be specified")
-        elif title:
+        if title:
             if auto_suggest:
                 temp_title = self.suggest(title)
                 if temp_title is None:  # page doesn't exist
                     raise PageError(title=title)
-                else:
-                    title = temp_title
+                title = temp_title
             return MediaWikiPage(self, title, redirect=redirect, preload=preload)
         return MediaWikiPage(self, pageid=pageid, preload=preload)
 

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -944,10 +944,9 @@ class MediaWiki(object):
             err = response["error"]["info"]
             if err in http_error:
                 raise HTTPTimeoutError(query)
-            elif err in geo_error:
+            if err in geo_error:
                 raise MediaWikiGeoCoordError(err)
-            else:
-                raise MediaWikiException(err)
+            raise MediaWikiException(err)
 
     @staticmethod
     def _check_query(value, message):

--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -46,6 +46,28 @@ class MediaWiki(object):
             username (str): The username to use to log into the MediaWiki
             password (str): The password to use to log into the MediaWiki """
 
+    __slots__ = [
+        "_version",
+        "_lang",
+        "_api_url",
+        "_cat_prefix",
+        "_timeout",
+        "_user_agent",
+        "_session",
+        "_rate_limit",
+        "_rate_limit_last_call",
+        "_min_wait",
+        "_extensions",
+        "_api_version",
+        "_api_version_str",
+        "_base_url",
+        "__supported_languages",
+        "_cache",
+        "_refresh_interval",
+        "_use_cache",
+        "_is_logged_in",
+    ]
+
     def __init__(
         self,
         url="https://{lang}.wikipedia.org/w/api.php",
@@ -577,7 +599,6 @@ class MediaWiki(object):
         res = list()
         for i, item in enumerate(results[1]):
             res.append((item, results[2][i], results[3][i]))
-
         return res
 
     @memoize
@@ -839,8 +860,7 @@ class MediaWiki(object):
                 else:
                     title = temp_title
             return MediaWikiPage(self, title, redirect=redirect, preload=preload)
-        else:  # must be pageid
-            return MediaWikiPage(self, pageid=pageid, preload=preload)
+        return MediaWikiPage(self, pageid=pageid, preload=preload)
 
     def wiki_request(self, params):
         """ Make a request to the MediaWiki API using the given search

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -43,6 +43,30 @@ class MediaWikiPage(object):
         Warning:
             This should never need to be used directly! Please use \
             :func:`mediawiki.MediaWiki.page` """
+    __slots__ = [
+        "mediawiki",
+        "url",
+        "title",
+        "original_title",
+        "pageid",
+        "_content",
+        "_revision_id",
+        "_parent_id",
+        "_html",
+        "_images",
+        "_references",
+        "_categories",
+        "_coordinates",
+        "_links",
+        "_redirects",
+        "_backlinks",
+        "_langlinks",
+        "_summary",
+        "_sections",
+        "_table_of_contents",
+        "_logos",
+        "_hatnotes",
+    ]
 
     def __init__(
         self,
@@ -99,7 +123,7 @@ class MediaWikiPage(object):
         if preload:
             for prop in preload_props:
                 getattr(self, prop)
-        # end __init__
+    # end __init__
 
     def __repr__(self):
         """ repr """
@@ -763,10 +787,7 @@ class MediaWikiPage(object):
             request = self.mediawiki.wiki_request(params)
             idx += 1
 
-            # print(idx)
-            # quick exit
             if "query" not in request:
-                # print(request)
                 break
 
             keys = [

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -563,8 +563,7 @@ class MediaWikiPage(object):
         """ raise the correct type of page error """
         if hasattr(self, "title"):
             raise PageError(title=self.title)
-        else:
-            raise PageError(pageid=self.pageid)
+        raise PageError(pageid=self.pageid)
 
     def _raise_disambiguation_error(self, page, pageid):
         """ parse and throw a disambiguation error """
@@ -675,7 +674,7 @@ class MediaWikiPage(object):
         for node in soup.find(id=id_tag).parent.next_siblings:
             if not isinstance(node, Tag):
                 continue
-            elif node.get("role", "") == "navigation":
+            if node.get("role", "") == "navigation":
                 continue
             elif "infobox" in node.get("class", []):
                 continue
@@ -684,7 +683,7 @@ class MediaWikiPage(object):
             is_headline = node.find("span", {"class": "mw-headline"})
             if is_headline is not None:
                 break
-            elif node.name == "a":
+            if node.name == "a":
                 all_links.append(self.__parse_link_info(node))
             else:
                 for link in node.findAll("a"):

--- a/scripts/py-lint.sh
+++ b/scripts/py-lint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+pip install pylint --upgrade
+
 pylint mediawiki/
 
 echo 'pylint status code:' $?

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     test_suite="tests",
 )


### PR DESCRIPTION
* use `__slots__` for classes
* handle the lack of the `TextExtracts` extension by throwing an exception if it is needed/used Resolves #82 