### PR TITLE
fix suggest

### DIFF
--- a/mediawiki/mediawiki.py
+++ b/mediawiki/mediawiki.py
@@ -500,7 +500,7 @@ class MediaWiki(object):
                                 suggestion found """
         res, suggest = self.search(query, results=1, suggestion=True)
         try:
-            title = suggest or res[0]
+            title = res[0] or suggest
         except IndexError:  # page doesn't exist
             title = None
         return title


### PR DESCRIPTION
Currently the suggest function returns the suggested title even if the searched title exists. For example, although the page [Charli D'Amelio](https://en.wikipedia.org/wiki/Charli_D'Amelio) exists, `page(r"Charli D'Amelio")` returns an error because `suggest` changes the query to `charlie d amelia`


```
Traceback (most recent call last):
  File "paths.py", line 39, in <module>
    page = wikipedia.page(r"Charli D'Amelio")
  File "/usr/local/lib/python3.8/site-packages/mediawiki/mediawiki.py", line 842, in page
    return MediaWikiPage(self, title, redirect=redirect, preload=preload)
  File "/usr/local/lib/python3.8/site-packages/mediawiki/mediawikipage.py", line 85, in __init__
    self.__load(redirect=redirect, preload=preload)
  File "/usr/local/lib/python3.8/site-packages/mediawiki/mediawikipage.py", line 521, in __load
    self._raise_page_error()
  File "/usr/local/lib/python3.8/site-packages/mediawiki/mediawikipage.py", line 536, in _raise_page_error
    raise PageError(title=self.title)
mediawiki.exceptions.PageError: "charlie d amelia" does not match any pages. Try another query!
```
Fixing it so that the suggest function returns the searched title if it exists, and then the suggested one.