### PR TITLE
Allow parsing links in the first part of a page, between the main title and the first section.

### DIFF
--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -516,8 +516,8 @@ class MediaWikiPage(object):
                 This is a parsing operation and not part of the standard API"""
         # Cache the results of parsing the html, so that multiple calls happen much faster
         if not self._soup:
-            self._soup = BeautifulSoup(self.html, "html.parser")        
-        
+            self._soup = BeautifulSoup(self.html, "html.parser")
+
         headlines = self._soup.find_all("span", class_="mw-headline")
         tmp_soup = BeautifulSoup(section_title, "html.parser")
         tmp_sec_title = tmp_soup.get_text().lower()
@@ -669,7 +669,7 @@ class MediaWikiPage(object):
 
     def _parse_section_links(self, id_tag):
         """ given a section id, parse the links in the unordered list """
-    
+
         info = self._soup.find("span", {"id": id_tag})
         all_links = list()
 

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -520,7 +520,7 @@ class MediaWikiPage(object):
             self._soup = BeautifulSoup(self.html, "html.parser")
 
         if section_title == 0:
-            self._parse_section_links(0)
+            return self._parse_section_links(0)
 
         headlines = self._soup.find_all("span", class_="mw-headline")
         tmp_soup = BeautifulSoup(section_title, "html.parser")

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -505,7 +505,8 @@ class MediaWikiPage(object):
         """ Parse all links within a section
 
             Args:
-                section_title (str): Name of the section to pull
+                section_title (str or 0): Name of the section to pull, 0 for all text
+                between the main heading and the first section.
             Returns:
                 list: List of (title, url) tuples
             Note:
@@ -517,6 +518,9 @@ class MediaWikiPage(object):
         # Cache the results of parsing the html, so that multiple calls happen much faster
         if not self._soup:
             self._soup = BeautifulSoup(self.html, "html.parser")
+
+        if section_title == 0:
+            self._parse_section_links(0)
 
         headlines = self._soup.find_all("span", class_="mw-headline")
         tmp_soup = BeautifulSoup(section_title, "html.parser")
@@ -669,21 +673,33 @@ class MediaWikiPage(object):
 
     def _parse_section_links(self, id_tag):
         """ given a section id, parse the links in the unordered list """
-
-        info = self._soup.find("span", {"id": id_tag})
         all_links = list()
 
-        if info is None:
-            return all_links
+        if id_tag == 0:
+            root = self._soup.find("div", {"class": "mw-parser-output"})
 
-        for node in self._soup.find(id=id_tag).parent.next_siblings:
+            if root is None:
+                return all_links
+
+            candidates = root.children
+        else:
+            root = self._soup.find("span", {"id": id_tag})
+            if root is None:
+                return all_links
+            candidates = self._soup.find(id=id_tag).parent.next_siblings
+
+        for node in candidates:
             if not isinstance(node, Tag):
                 continue
             if node.get("role", "") == "navigation":
                 continue
             elif "infobox" in node.get("class", []):
                 continue
-
+            # If the classname contains "toc", the element is a table of contents.
+            # The comprehension is necessary because there are several possible types of tocs: "toclevel", "toc", ...
+            toc_classnames = [classname for classname in node.get("class", []) if "toc" in classname]
+            if toc_classnames:
+                continue
             # this is actually the child node's class...
             is_headline = node.find("span", {"class": "mw-headline"})
             if is_headline is not None:

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -54,6 +54,7 @@ class MediaWikiPage(object):
         "_revision_id",
         "_parent_id",
         "_html",
+        "_soup",
         "_images",
         "_references",
         "_categories",
@@ -106,6 +107,7 @@ class MediaWikiPage(object):
         self._table_of_contents = None
         self._logos = None
         self._hatnotes = None
+        self._soup = None
 
         self.__load(redirect=redirect, preload=preload)
 
@@ -512,8 +514,12 @@ class MediaWikiPage(object):
                 Side effect is to also pull the html which can be slow
             Note:
                 This is a parsing operation and not part of the standard API"""
-        soup = BeautifulSoup(self.html, "html.parser")
-        headlines = soup.find_all("span", class_="mw-headline")
+        # Cache the results of parsing the html, so that multiple calls happen much faster
+        print("using custom function")
+        if not self._soup:
+            self._soup = BeautifulSoup(self.html, "html.parser")        
+        
+        headlines = self._soup.find_all("span", class_="mw-headline")
         tmp_soup = BeautifulSoup(section_title, "html.parser")
         tmp_sec_title = tmp_soup.get_text().lower()
         id_tag = None
@@ -664,14 +670,14 @@ class MediaWikiPage(object):
 
     def _parse_section_links(self, id_tag):
         """ given a section id, parse the links in the unordered list """
-        soup = BeautifulSoup(self.html, "html.parser")
-        info = soup.find("span", {"id": id_tag})
+    
+        info = self._soup.find("span", {"id": id_tag})
         all_links = list()
 
         if info is None:
             return all_links
 
-        for node in soup.find(id=id_tag).parent.next_siblings:
+        for node in self._soup.find(id=id_tag).parent.next_siblings:
             if not isinstance(node, Tag):
                 continue
             if node.get("role", "") == "navigation":

--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -515,7 +515,6 @@ class MediaWikiPage(object):
             Note:
                 This is a parsing operation and not part of the standard API"""
         # Cache the results of parsing the html, so that multiple calls happen much faster
-        print("using custom function")
         if not self._soup:
             self._soup = BeautifulSoup(self.html, "html.parser")        
         


### PR DESCRIPTION
I'm not sure about what the best argument would be to `parse_section_titles` - for now, it downloads the first section if a `0` is passed to it. I also changed the inline documentation. If you have other suggestions, I'm open.
