### PR TITLE
Feature/disambiguation non sorted

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # PyPi
 .pypirc
+
+# vscode
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Future Release
 
-* Add `unordered_options` to the `DisambiguationError` to attempt to get options in the order presented on the page; [issue #125](https://github.com/barrust/mediawiki/issues/125)
+* Add `unordered_options` to the `DisambiguationError` to attempt to get options in the order presented on the page; [issue #124](https://github.com/barrust/mediawiki/issues/124)
 
 ## Version 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MediaWiki Changelog
 
+## Future Release
+
+* Add `unordered_options` to the `DisambiguationError` to attempt to get options in the order presented on the page; [issue #125](https://github.com/barrust/mediawiki/issues/125)
+
 ## Version 0.7.2
 
 * Add `page_preview` property to simulate the page preview hover [PR #114](https://github.com/barrust/mediawiki/pull/114)

--- a/mediawiki/exceptions.py
+++ b/mediawiki/exceptions.py
@@ -3,7 +3,6 @@ MediaWiki Exceptions
 """
 from .utilities import str_or_unicode
 
-
 ODD_ERROR_MESSAGE = (
     "This should not happen. If the MediaWiki site you are "
     "querying is available, then please report this issue on "
@@ -128,6 +127,7 @@ class DisambiguationError(MediaWikiBaseException):
 
     def __init__(self, title, may_refer_to, url, details=None):
         self._title = title
+        self._unordered_options = may_refer_to
         self._options = sorted(may_refer_to)
         self._details = details
         self._url = url
@@ -150,6 +150,11 @@ class DisambiguationError(MediaWikiBaseException):
     def options(self):
         """ list: The list of possible page titles """
         return self._options
+
+    @property
+    def unordered_options(self):
+        """list: The list of possible page titles, un-sorted in an attempt to get them as they showup on the page"""
+        return self._unordered_options
 
     @property
     def details(self):


### PR DESCRIPTION
resolves #124 

* Add `unordered_options` to the `DisambiguationError` to attempt to get options in the order presented on the page