### PR TITLE
Add support for HTTP authentication

### DIFF
--- a/mediawiki/configuraton.py
+++ b/mediawiki/configuraton.py
@@ -1,10 +1,12 @@
 """Configuration module"""
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 URL: str = "https://github.com/barrust/mediawiki"
 VERSION: str = "0.7.4"
+
+HTTPAuthenticator = Union[Tuple[str, str], Callable[[Any], Any]]
 
 
 @dataclass
@@ -24,6 +26,7 @@ class Configuration:
     _password: Optional[str] = field(default=None, init=False, repr=False)
     _refresh_interval: Optional[int] = field(default=None, init=False, repr=False)
     _use_cache: bool = field(default=True, init=False, repr=False)
+    _http_auth: Optional[HTTPAuthenticator] = field(default=None, init=False, repr=False)
 
     #  not in repr
     _reset_session: bool = field(default=True, init=False, repr=False)
@@ -45,6 +48,7 @@ class Configuration:
         password: Optional[str] = None,
         refresh_interval: Optional[int] = None,
         use_cache: bool = True,
+        http_auth: Optional[HTTPAuthenticator] = None,
     ):
         if api_url:
             self._api_url = api_url
@@ -84,6 +88,9 @@ class Configuration:
 
         if timeout:
             self.timeout = timeout
+
+        if http_auth:
+            self.http_auth = http_auth
 
     def __repr__(self):
         """repr"""
@@ -268,3 +275,13 @@ class Configuration:
     def timeout(self, timeout: Optional[float]):
         """Set request timeout in seconds (or fractions of a second)"""
         self._timeout = None if timeout is None else float(timeout)
+
+    @property
+    def http_auth(self) -> Optional[HTTPAuthenticator]:
+        """tuple|callable: HTTP authenticator to use to access the mediawiki site"""
+        return self._http_auth
+
+    @http_auth.setter
+    def http_auth(self, http_auth: Optional[HTTPAuthenticator]):
+        """Set the HTTP authenticator, if needed, to use to access the mediawiki site"""
+        self._http_auth = http_auth

--- a/tests/mediawiki_test.py
+++ b/tests/mediawiki_test.py
@@ -41,6 +41,7 @@ class MediaWikiOverloaded(MediaWiki):
         password=None,
         proxies=None,
         verify_ssl=True,
+        http_auth=None,
     ):
         """new init"""
 
@@ -63,6 +64,7 @@ class MediaWikiOverloaded(MediaWiki):
             password=password,
             proxies=proxies,
             verify_ssl=verify_ssl,
+            http_auth=http_auth,
         )
 
     def __repr__(self):
@@ -167,6 +169,7 @@ class TestMediaWiki(unittest.TestCase):
         site = MediaWikiOverloaded()
         res = (
             "Configuration(api_url=https://en.wikipedia.org/w/api.php, category_prefix=Category, "
+            "http_auth=None, "
             "lang=en, password=None, proxies=None, rate_limit=False, rate_limit_min_wait=0:00:00.050000, "
             "refresh_interval=None, timeout=15.0, use_cache=True, "
             "user_agent=python-mediawiki/VERSION-0.7.4/(https://github.com/barrust/mediawiki)/BOT, username=None, verify_ssl=True)"
@@ -266,6 +269,35 @@ class TestMediaWiki(unittest.TestCase):
     def test_set_timeout_bad(self):
         """test that we raise the ValueError"""
         self.assertRaises(ValueError, lambda: MediaWikiOverloaded(timeout="foo"))
+
+    def test_default_http_auth(self):
+        """test default HTTP authenticator"""
+        site = MediaWikiOverloaded()
+        self.assertIs(site.http_auth, None)
+        self.assertIs(site._session.auth, None)
+
+    def test_init_user_agent(self):
+        """test initializing the HTTP authenticator"""
+        auth_func = lambda http_request: http_request
+        site = MediaWikiOverloaded(http_auth=auth_func)
+        self.assertIs(site.http_auth, auth_func)
+        self.assertIs(site._session.auth, auth_func)
+
+    def test_set_http_auth(self):
+        """test setting HTTP authenticator"""
+        site = MediaWikiOverloaded()
+        auth_tuple = ("username", "password")
+        site.http_auth = auth_tuple
+        self.assertIs(site.http_auth, auth_tuple)
+        self.assertIs(site._session.auth, auth_tuple)
+
+    def test_set_http_auth_none(self):
+        """test setting HTTP authenticator to None"""
+        auth_func = lambda http_request: http_request
+        site = MediaWikiOverloaded(http_auth=auth_func)
+        site.http_auth = None
+        self.assertIs(site.http_auth, None)
+        self.assertIs(site._session.auth, None)
 
     def test_memoized(self):
         """test returning the memoized cache"""


### PR DESCRIPTION
This pull request adds support for [HTTP authentication](https://docs.python-requests.org/en/latest/user/authentication/), by adding an `http_auth` argument and property to `MediaWiki`. Whatever you pass/set as `http_auth` gets passed to Requests as an `auth` parameter, so you can do any of these:

```python
from requests.auth import HTTPBasicAuth
wiki = MediaWiki(..., http_auth=HTTPBasicAuth("username", "Pa5sW0rD"))
```

or:

```python
wiki = MediaWiki(..., http_auth=("username", "Pa5sW0rD"))  # shortcut for basic auth
```
or:
```python
from requests.auth import HTTPDigestAuth
wiki = MediaWiki(...)
wiki.http_auth=HTTPDigestAuth("username", "Pa5sW0rD")
```
